### PR TITLE
Properly nest connection

### DIFF
--- a/steps/microsoft-teams-step-send-message/spec.schema.json
+++ b/steps/microsoft-teams-step-send-message/spec.schema.json
@@ -1,19 +1,36 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-      "incomingWebhookURL": {
-        "type": "string",
-        "description": "An incoming webhook URL for the Microsoft Teams API"
-      },
-      "message": {
-        "type": "string",
-        "description": "The message to send."
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "object",
+      "description": "A Microsoft Teams connection mapping.",
+      "properties": {
+        "connection": {
+          "type": "object",
+          "x-relay-connectionType": "msteams",
+          "description": "A Relay Microsoft Teams connection",
+          "properties": {
+            "incomingWebhookURL": {
+              "type": "string",
+              "description": "An incoming webhook URL for the Microsoft Teams API"
+            }
+          },
+          "required": [
+            "incomingWebhookURL"
+          ]
+        }
       }
     },
-    "required": [
-      "incomingWebhookURL",
-      "message"
-    ],
-    "additionalProperties": false
-  }
+    "message": {
+      "type": "string",
+      "description": "The message to send."
+    }
+  },
+  "required": [
+    "connection",
+    "message"
+  ],
+  "additionalProperties": false
+}
+

--- a/steps/microsoft-teams-step-send-message/step.sh
+++ b/steps/microsoft-teams-step-send-message/step.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 MESSAGE=$(ni get -p '{.message}')
-WEBHOOK_URL=$(ni get -p '{.incomingWebhookURL}')
+WEBHOOK_URL=$(ni get -p '{.connection.incomingWebhookURL}')
 
 if [ -z "${WEBHOOK_URL}" ]; then
   WEBHOOK_URL=$(ni get -p '{.webhookURL}')
 fi
 
 if [ -z "${WEBHOOK_URL}" ]; then
-  echo "No webhookURL specified"
+  echo "No incoming webhook url specified"
   exit 1
 fi
 if [ -z "${MESSAGE}" ]; then

--- a/steps/microsoft-teams-step-send-message/step.yaml
+++ b/steps/microsoft-teams-step-send-message/step.yaml
@@ -52,4 +52,4 @@ examples:
     image: relaysh/microsoft-teams-step-send-message
     spec:
       message: !Parameter message 
-      incomingWebhookURL: !Connection { type: msteams, name: my-team }
+      connection: !Connection { type: msteams, name: my-team }


### PR DESCRIPTION
The connection supplies an `incomingWebhookURL` property. The step, schema, and example were all incorrect in different ways with respect to this.